### PR TITLE
Feat: add appropiate lang attribute for documents and preferences dialog

### DIFF
--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -18,6 +18,7 @@ const store = configureStore(initialState, 'renderer');
 
 const initLanguage = store.getState().preferences.language || getDefaultLanguage();
 setCurrentLanguage(initLanguage);
+document.documentElement.setAttribute("lang", initLanguage);
 
 store.subscribe(() => {
   const state = store.getState();
@@ -26,6 +27,7 @@ store.subscribe(() => {
 
   if (prefs.language) {
     setCurrentLanguage(prefs.language);
+    document.documentElement.setAttribute("lang", prefs.language);
   }
 });
 


### PR DESCRIPTION
- Set lang attribute to document.element according to the initial or chosen language.
- Useful when screen readers are configured to detect language changes.

Important for accessibility, since documents should define their main language