### PR TITLE
feat: set default localization according to navigator language

### DIFF
--- a/src/main/main.js
+++ b/src/main/main.js
@@ -23,7 +23,7 @@ import {startKnowledgeBaseServer, stopKnowledgeBaseServer, closeKnowledgeBaseWin
 import { prepareLaunch } from '@daisy/ace-axe-runner-electron/lib/init';
 
 import { localizer } from './../shared/l10n/localize';
-const { localize } = localizer;
+const { localize, setCurrentLanguage, getRawResources, getDefaultLanguage } = localizer;
 
 const isDev = process && process.env && (process.env.NODE_ENV === 'development' || process.env.DEBUG_PROD === 'true');
 
@@ -280,6 +280,17 @@ function createWindow() {
 // app.setAccessibilitySupportEnabled(true);
 
 app.on('ready', () => {
+  const res = getRawResources()
+  const languageKeys = Object.keys(res);
+  if (store.getState().preferences.language === undefined) {
+    if (languageKeys.includes(app.getLocale()))  {
+      store.getState().preferences.language = app.getLocale();
+    } else {
+      store.getState().preferences.language = getDefaultLanguage();
+    }
+    setCurrentLanguage(store.getState().preferences.language);
+  }
+
   // The Electron app is always run from the ./app/main-bundle.js folder which contains a subfolder copy of the KB
   // ... so this is not needed (and __dirname works in ASAR and non-ASAR mode)
   // const isNotPackaged = process && process.env && process.env.ACE_IS_NOT_PACKAGED === 'true';

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -36,9 +36,6 @@ if (isDev) {
 const initialState = getInitialStateRenderer();
 const store = configureStore(initialState, 'renderer');
 
-if (store.getState().preferences.language === undefined) {
-	store.getState().preferences.language = navigator.language;
-}
 const initLanguage = store.getState().preferences.language || getDefaultLanguage();
 setCurrentLanguage(initLanguage);
 document.documentElement.setAttribute("lang", getCurrentLanguage());

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -12,7 +12,7 @@ import {
 } from './../shared/actions/app';
 
 import { localizer } from './../shared/l10n/localize';
-const { getDefaultLanguage, setCurrentLanguage } = localizer;
+const { getDefaultLanguage, setCurrentLanguage, getCurrentLanguage } = localizer;
 
 const isDev = process && process.env && (process.env.NODE_ENV === 'development' || process.env.DEBUG_PROD === 'true');
 if (isDev) {
@@ -36,9 +36,12 @@ if (isDev) {
 const initialState = getInitialStateRenderer();
 const store = configureStore(initialState, 'renderer');
 
+if (store.getState().preferences.language === undefined) {
+	store.getState().preferences.language = navigator.language;
+}
 const initLanguage = store.getState().preferences.language || getDefaultLanguage();
 setCurrentLanguage(initLanguage);
-document.documentElement.setAttribute("lang", initLanguage);
+document.documentElement.setAttribute("lang", getCurrentLanguage());
 
 store.subscribe(() => {
   const state = store.getState();
@@ -47,7 +50,7 @@ store.subscribe(() => {
 
   if (prefs.language) {
     setCurrentLanguage(prefs.language);
-    document.documentElement.setAttribute("lang", prefs.language);
+    document.documentElement.setAttribute("lang", getCurrentLanguage());
   }
 });
 

--- a/src/shared/default-preferences.js
+++ b/src/shared/default-preferences.js
@@ -5,7 +5,7 @@ import { localizer } from './l10n/localize';
 const { getDefaultLanguage } = localizer;
 
 export const defaultPreferences = {
-  language: getDefaultLanguage(),
+  // language: getDefaultLanguage(),
   reports: {
     dir: tmp.dirSync({ unsafeCleanup: true }).name,
     organize: true,


### PR DESCRIPTION
Use navigator language to determine the localization when no preferences have been set, ensuring that pronnounciation is right for screen readers.

Fixes #46